### PR TITLE
Made JsRuntime and JsObjectRef public for building third party libraries

### DIFF
--- a/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
+++ b/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
@@ -6,8 +6,8 @@ namespace BrowserInterop.Extensions
 {
     public abstract class JsObjectWrapperBase : IAsyncDisposable
     {
-        public JsRuntimeObjectRef JsObjectRef { get; private set; }
-        public IJSRuntime JsRuntime { get; private set; }
+        protected internal JsRuntimeObjectRef JsObjectRef { get; private set; }
+        protected internal IJSRuntime JsRuntime { get; private set; }
 
         internal virtual void SetJsRuntime(IJSRuntime jsRuntime, JsRuntimeObjectRef jsObjectRef)
         {

--- a/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
+++ b/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
@@ -6,8 +6,8 @@ namespace BrowserInterop.Extensions
 {
     public abstract class JsObjectWrapperBase : IAsyncDisposable
     {
-        protected JsRuntimeObjectRef JsObjectRef { get; private set; }
-        protected IJSRuntime JsRuntime { get; private set; }
+        protected internal JsRuntimeObjectRef JsObjectRef { get; private set; }
+        protected internal IJSRuntime JsRuntime { get; private set; }
 
         internal virtual void SetJsRuntime(IJSRuntime jsRuntime, JsRuntimeObjectRef jsObjectRef)
         {

--- a/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
+++ b/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
@@ -6,8 +6,8 @@ namespace BrowserInterop.Extensions
 {
     public abstract class JsObjectWrapperBase : IAsyncDisposable
     {
-        internal JsRuntimeObjectRef JsObjectRef { get; private set; }
-        internal IJSRuntime JsRuntime { get; private set; }
+        public JsRuntimeObjectRef JsObjectRef { get; private set; }
+        public IJSRuntime JsRuntime { get; private set; }
 
         internal virtual void SetJsRuntime(IJSRuntime jsRuntime, JsRuntimeObjectRef jsObjectRef)
         {

--- a/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
+++ b/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
@@ -6,8 +6,8 @@ namespace BrowserInterop.Extensions
 {
     public abstract class JsObjectWrapperBase : IAsyncDisposable
     {
-        protected internal JsRuntimeObjectRef JsObjectRef { get; private set; }
-        protected internal IJSRuntime JsRuntime { get; private set; }
+        public JsRuntimeObjectRef JsObjectRef { get; private set; }
+        public IJSRuntime JsRuntime { get; private set; }
 
         internal virtual void SetJsRuntime(IJSRuntime jsRuntime, JsRuntimeObjectRef jsObjectRef)
         {

--- a/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
+++ b/src/BrowserInterop/Extensions/JsObjectWrapperBase.cs
@@ -6,8 +6,8 @@ namespace BrowserInterop.Extensions
 {
     public abstract class JsObjectWrapperBase : IAsyncDisposable
     {
-        public JsRuntimeObjectRef JsObjectRef { get; private set; }
-        public IJSRuntime JsRuntime { get; private set; }
+        protected JsRuntimeObjectRef JsObjectRef { get; private set; }
+        protected IJSRuntime JsRuntime { get; private set; }
 
         internal virtual void SetJsRuntime(IJSRuntime jsRuntime, JsRuntimeObjectRef jsObjectRef)
         {


### PR DESCRIPTION
This pull-request allow to inherit in third party library from `JsObjectWrapperBase` and have access to properties of this object