### PR TITLE
Debounce and fix for default values in serialization filter 

### DIFF
--- a/src/BrowserInterop/BrowserInterop.csproj
+++ b/src/BrowserInterop/BrowserInterop.csproj
@@ -6,7 +6,7 @@
     <PackageId>BrowserInterop</PackageId>
     <Authors>Rémi BOURGAREL</Authors>
     <Company>Rémi BOURGAREL</Company>
-    <PackageVersion>1.1.1.13</PackageVersion>
+    <PackageVersion>1.1.2.18</PackageVersion>
     <PackageDescription>Library  wrapping Blazor JSInterop call for browser API : console, navigator, battery, geolocation, storage (local, session), history, screen, performance, window, event ... see wiki for list of supported API</PackageDescription>
     <Copyright>Rémi BOURGAREL</Copyright>
     <PackageTags>blazor; browser; navigator; geolocation; console; jsinterop</PackageTags>

--- a/src/BrowserInterop/BrowserInterop.csproj
+++ b/src/BrowserInterop/BrowserInterop.csproj
@@ -6,7 +6,7 @@
     <PackageId>BrowserInterop</PackageId>
     <Authors>Rémi BOURGAREL</Authors>
     <Company>Rémi BOURGAREL</Company>
-    <PackageVersion>1.1.1</PackageVersion>
+    <PackageVersion>1.1.2</PackageVersion>
     <PackageDescription>Library  wrapping Blazor JSInterop call for browser API : console, navigator, battery, geolocation, storage (local, session), history, screen, performance, window, event ... see wiki for list of supported API</PackageDescription>
     <Copyright>Rémi BOURGAREL</Copyright>
     <PackageTags>blazor; browser; navigator; geolocation; console; jsinterop</PackageTags>

--- a/src/BrowserInterop/BrowserInterop.csproj
+++ b/src/BrowserInterop/BrowserInterop.csproj
@@ -6,7 +6,7 @@
     <PackageId>BrowserInterop</PackageId>
     <Authors>Rémi BOURGAREL</Authors>
     <Company>Rémi BOURGAREL</Company>
-    <PackageVersion>1.1.1.1</PackageVersion>
+    <PackageVersion>1.1.1.3</PackageVersion>
     <PackageDescription>Library  wrapping Blazor JSInterop call for browser API : console, navigator, battery, geolocation, storage (local, session), history, screen, performance, window, event ... see wiki for list of supported API</PackageDescription>
     <Copyright>Rémi BOURGAREL</Copyright>
     <PackageTags>blazor; browser; navigator; geolocation; console; jsinterop</PackageTags>

--- a/src/BrowserInterop/BrowserInterop.csproj
+++ b/src/BrowserInterop/BrowserInterop.csproj
@@ -6,7 +6,7 @@
     <PackageId>BrowserInterop</PackageId>
     <Authors>Rémi BOURGAREL</Authors>
     <Company>Rémi BOURGAREL</Company>
-    <PackageVersion>1.1.1.3</PackageVersion>
+    <PackageVersion>1.1.1.11</PackageVersion>
     <PackageDescription>Library  wrapping Blazor JSInterop call for browser API : console, navigator, battery, geolocation, storage (local, session), history, screen, performance, window, event ... see wiki for list of supported API</PackageDescription>
     <Copyright>Rémi BOURGAREL</Copyright>
     <PackageTags>blazor; browser; navigator; geolocation; console; jsinterop</PackageTags>

--- a/src/BrowserInterop/BrowserInterop.csproj
+++ b/src/BrowserInterop/BrowserInterop.csproj
@@ -6,7 +6,7 @@
     <PackageId>BrowserInterop</PackageId>
     <Authors>Rémi BOURGAREL</Authors>
     <Company>Rémi BOURGAREL</Company>
-    <PackageVersion>1.1.2</PackageVersion>
+    <PackageVersion>1.1.1.1</PackageVersion>
     <PackageDescription>Library  wrapping Blazor JSInterop call for browser API : console, navigator, battery, geolocation, storage (local, session), history, screen, performance, window, event ... see wiki for list of supported API</PackageDescription>
     <Copyright>Rémi BOURGAREL</Copyright>
     <PackageTags>blazor; browser; navigator; geolocation; console; jsinterop</PackageTags>

--- a/src/BrowserInterop/BrowserInterop.csproj
+++ b/src/BrowserInterop/BrowserInterop.csproj
@@ -6,7 +6,7 @@
     <PackageId>BrowserInterop</PackageId>
     <Authors>Rémi BOURGAREL</Authors>
     <Company>Rémi BOURGAREL</Company>
-    <PackageVersion>1.1.1.12</PackageVersion>
+    <PackageVersion>1.1.1.13</PackageVersion>
     <PackageDescription>Library  wrapping Blazor JSInterop call for browser API : console, navigator, battery, geolocation, storage (local, session), history, screen, performance, window, event ... see wiki for list of supported API</PackageDescription>
     <Copyright>Rémi BOURGAREL</Copyright>
     <PackageTags>blazor; browser; navigator; geolocation; console; jsinterop</PackageTags>

--- a/src/BrowserInterop/BrowserInterop.csproj
+++ b/src/BrowserInterop/BrowserInterop.csproj
@@ -6,7 +6,7 @@
     <PackageId>BrowserInterop</PackageId>
     <Authors>Rémi BOURGAREL</Authors>
     <Company>Rémi BOURGAREL</Company>
-    <PackageVersion>1.1.1.11</PackageVersion>
+    <PackageVersion>1.1.1.12</PackageVersion>
     <PackageDescription>Library  wrapping Blazor JSInterop call for browser API : console, navigator, battery, geolocation, storage (local, session), history, screen, performance, window, event ... see wiki for list of supported API</PackageDescription>
     <Copyright>Rémi BOURGAREL</Copyright>
     <PackageTags>blazor; browser; navigator; geolocation; console; jsinterop</PackageTags>

--- a/src/BrowserInterop/Extensions/BrowserInteropJsRuntimeExtension.cs
+++ b/src/BrowserInterop/Extensions/BrowserInteropJsRuntimeExtension.cs
@@ -151,7 +151,7 @@ namespace BrowserInterop.Extensions
         public static async ValueTask InvokeInstanceMethod(this IJSRuntime jsRuntime, JsRuntimeObjectRef windowObject,
             string methodName, params object[] arguments)
         {
-            await jsRuntime.InvokeVoidAsync("browserInterop.callInstanceMethod",
+            await jsRuntime.InvokeVoidAsync("browserInterop.callInstanceAction",
                 new object[] {windowObject, methodName}.Concat(arguments).ToArray()).ConfigureAwait(false);
         }
 

--- a/src/BrowserInterop/Extensions/BrowserInteropJsRuntimeExtension.cs
+++ b/src/BrowserInterop/Extensions/BrowserInteropJsRuntimeExtension.cs
@@ -210,6 +210,7 @@ namespace BrowserInterop.Extensions
         }
 
 
+
         /// <summary>
         /// Call the method on the js instance and return the reference to the js object
         /// </summary>
@@ -225,9 +226,34 @@ namespace BrowserInterop.Extensions
 
             var jsRuntimeObjectRef = await jsRuntime.InvokeAsync<JsRuntimeObjectRef>(
                 "browserInterop.callInstanceMethodGetRef",
-                new object[] {windowObject, methodName}.Concat(arguments).ToArray()).ConfigureAwait(false);
+                new object[] { windowObject, methodName }.Concat(arguments).ToArray()).ConfigureAwait(false);
             jsRuntimeObjectRef.JsRuntime = jsRuntime;
             return jsRuntimeObjectRef;
+        }
+
+
+        /// <summary>
+        /// Call the method on the js instance and return the references to the items of the array result
+        /// </summary>
+        /// <param name="jsRuntime">Current JS Runtime</param>
+        /// <param name="windowObject">Reference to the JS instance</param>
+        /// <param name="methodName">Method name/path </param>
+        /// <param name="arguments">method arguments</param>
+        /// <returns></returns>
+        public static async ValueTask<JsRuntimeObjectRef[]> InvokeInstanceMethodGetRefs(this IJSRuntime jsRuntime,
+            JsRuntimeObjectRef windowObject, string methodName, params object[] arguments)
+        {
+            if (jsRuntime is null) throw new ArgumentNullException(nameof(jsRuntime));
+
+            var jsRuntimeObjectRefs = await jsRuntime.InvokeAsync<JsRuntimeObjectRef[]>(
+                "browserInterop.callInstanceMethodGetRefs",
+                new object[] {windowObject, methodName}.Concat(arguments).ToArray()).ConfigureAwait(false);
+          
+            foreach(var reference in jsRuntimeObjectRefs)
+            {
+                reference.JsRuntime = jsRuntime;
+            }
+            return jsRuntimeObjectRefs;
         }
 
         public static async ValueTask<bool> HasProperty(this IJSRuntime jsRuntime, JsRuntimeObjectRef jsObject,

--- a/src/BrowserInterop/Extensions/CallBackInteropWrapper.cs
+++ b/src/BrowserInterop/Extensions/CallBackInteropWrapper.cs
@@ -35,6 +35,12 @@ namespace BrowserInterop.Extensions
         /// or if it should be postponed until no event is incomming within one debounce time period.
         /// </summary>
         public bool TriggerPermanent { get; set; }
+
+        /// <summary>
+        /// Determines whether default values of the serialized callback data shall be transmitted
+        /// </summary>
+        public bool IncludeDefaults { get; set; }
+
         private CallBackInteropWrapper()
         {
         }

--- a/src/BrowserInterop/Extensions/CallBackInteropWrapper.cs
+++ b/src/BrowserInterop/Extensions/CallBackInteropWrapper.cs
@@ -18,7 +18,23 @@ namespace BrowserInterop.Extensions
 
         public bool GetJsObjectRef { get; set; }
 
+        /// <summary>
+        /// Adds javascript side debounce to the callback (in milliseconds)
+        /// see https://davidwalsh.name/javascript-debounce-function
+        /// </summary>
+        public double? Debounce { get; set; }
 
+        /// <summary>
+        /// Determines whether the callback should be invoked at the first occurrance 
+        /// or if the invocation shall be postponed until the debounce timeout is expired.
+        /// </summary>
+        public bool Immediate { get; set; }
+
+        /// <summary>
+        /// Determines whether the callback shall be invoked always when the debounce time is expired
+        /// or if it should be postponed until no event is incomming within one debounce time period.
+        /// </summary>
+        public bool TriggerPermanent { get; set; }
         private CallBackInteropWrapper()
         {
         }

--- a/src/BrowserInterop/Extensions/JsInteropActionWrapper.cs
+++ b/src/BrowserInterop/Extensions/JsInteropActionWrapper.cs
@@ -7,46 +7,6 @@ namespace BrowserInterop.Extensions
     /// <summary>
     /// Wrap a c# action into an object invokable by JS
     /// </summary>
-    public class JsInteropActionWrapper
-    {
-        private readonly Func<ValueTask> toDo;
-
-        internal JsInteropActionWrapper(Func<ValueTask> toDo)
-        {
-            this.toDo = toDo;
-        }
-
-
-        [JSInvokable]
-        public async ValueTask Invoke()
-        {
-            await toDo.Invoke().ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>
-    /// Wrap a c# action into an object invokable by JS
-    /// </summary>
-    public class JsInteropActionWrapper<T>
-    {
-        private readonly Func<T, ValueTask> toDo;
-
-        internal JsInteropActionWrapper(Func<T, ValueTask> toDo)
-        {
-            this.toDo = toDo;
-        }
-
-
-        [JSInvokable]
-        public async ValueTask Invoke(T arg1)
-        {
-            await toDo.Invoke(arg1).ConfigureAwait(false);
-        }
-    }
-    
-    /// <summary>
-    /// Wrap a c# action into an object invokable by JS
-    /// </summary>
     public class JsInteropActionWrapperWithResult<T, TResult>
     {
         private readonly Func<T, ValueTask<TResult>> toDo;

--- a/src/BrowserInterop/wwwroot/scripts.js
+++ b/src/BrowserInterop/wwwroot/scripts.js
@@ -63,15 +63,24 @@ browserInterop = new (function () {
             var callback =  async function (...args) {
               
                 if (value.getArgumentsSerializationAndRef) {
-                    var passedArgs = args.map(arg => {
-                        return {
-                            Reference: me.storeObjectRef(arg),
-                            Data: me.getSerializableObject(arg, [], value.serializationSpec, value.includeDefaults)
-                        }
-                    });
+                    var passedArgs = [];
+
+                    if (value.hasParameter) {
+                         passedArgs = args.map(arg => {
+                            return {
+                                Reference: me.storeObjectRef(arg),
+                                Data: me.getSerializableObject(arg, [], value.serializationSpec, value.includeDefaults)
+                            }
+                        });
+                    }
+                   
+                    var argsObject = passedArgs.length == 0 ? null : passedArgs.length == 1 ? passedArgs[0] : passedArgs;
                     try {
-                        var result = await netObjectRef.invokeMethodAsync('Invoke', ...passedArgs);
+                        var result = await netObjectRef.invokeMethodAsync('Invoke', argsObject);
                         return result;
+                    }
+                    catch (e) {
+                        console.error(e);
                     }
                     finally {
                         passedArgs.forEach(arg => me.removeObjectRef(arg.Reference));
@@ -79,19 +88,23 @@ browserInterop = new (function () {
                 }
                 else {
                     var passedArgs = [];
-                    if (!value.getJsObjectRef) {
-                        for (let index = 0; index < arguments.length; index++) {
-                            const element = arguments[index];
-                            passedArgs.push(me.getSerializableObject(element, [], value.serializationSpec, value.includeDefaults));
-                        }
-                    } else {
-                        for (let index = 0; index < arguments.length; index++) {
-                            const element = arguments[index];
-                            passedArgs.push(me.storeObjectRef(element));
+
+                    if (value.hasParameter) {
+                        if (!value.getJsObjectRef) {
+                            for (let index = 0; index < arguments.length; index++) {
+                                const element = arguments[index];
+                                passedArgs.push(me.getSerializableObject(element, [], value.serializationSpec, value.includeDefaults));
+                            }
+                        } else {
+                            for (let index = 0; index < arguments.length; index++) {
+                                const element = arguments[index];
+                                passedArgs.push(me.storeObjectRef(element));
+                            }
                         }
                     }
+                    var argsObject = passedArgs.length == 0 ? null : passedArgs.length == 1 ? passedArgs[0] : passedArgs;
 
-                    var result = await netObjectRef.invokeMethodAsync('Invoke', ...passedArgs);
+                    var result = await netObjectRef.invokeMethodAsync('Invoke', argsObject);
                     return result;
 
                 }

--- a/src/BrowserInterop/wwwroot/scripts.js
+++ b/src/BrowserInterop/wwwroot/scripts.js
@@ -188,7 +188,7 @@ browserInterop = new (function () {
             var currentMemberSpec;
             if (serializationSpec != "*") {
                 currentMemberSpec = Array.isArray(data) ? serializationSpec : serializationSpec[i];
-                if (!currentMemberSpec) {
+                if (currentMemberSpec === undefined) {
                     continue;
                 }
             } else {

--- a/src/BrowserInterop/wwwroot/scripts.js
+++ b/src/BrowserInterop/wwwroot/scripts.js
@@ -220,7 +220,7 @@ browserInterop = new (function () {
             var currentMemberSpec;
             if (serializationSpec != "*") {
                 currentMemberSpec = Array.isArray(data) ? serializationSpec : serializationSpec[i];
-                if (currentMemberSpec === undefined) {
+                if (currentMemberSpec == null || currentMemberSpec === undefined) {
                     continue;
                 }
             } else {

--- a/src/BrowserInterop/wwwroot/scripts.js
+++ b/src/BrowserInterop/wwwroot/scripts.js
@@ -215,6 +215,13 @@ browserInterop = new (function () {
     this.callInstanceMethodGetRef = function (instance, methodPath, ...args) {
         return this.storeObjectRef(this.callInstanceMethod(instance, methodPath, ...args));
     };
+    this.callInstanceMethodGetRefs = function (instance, methodPath, ...args) {
+
+        var objects = this.callInstanceMethod(instance, methodPath, ...args);
+        var references = objects.map(arg => me.storeObjectRef(arg));
+        return references;
+    };
+
     this.getSerializableObject = function (data, alreadySerialized, serializationSpec, includeDefaults) {
         if (serializationSpec === false) {
             return undefined;

--- a/src/BrowserInterop/wwwroot/scripts.js
+++ b/src/BrowserInterop/wwwroot/scripts.js
@@ -191,6 +191,9 @@ browserInterop = new (function () {
         var res = me.getSerializableObject(data, [], serializationSpec);
         return res;
     };
+    this.callInstanceAction = function (instance, methodPath, ...args) {
+        this.callInstanceMethod(instance, methodPath, ...args);
+    }
     this.callInstanceMethod = function (instance, methodPath, ...args) {
         if (methodPath.indexOf('.') >= 0) {
             //if it's a method call on a child object we get this child object so the method call will happen in the context of the child object

--- a/src/BrowserInterop/wwwroot/scripts.js
+++ b/src/BrowserInterop/wwwroot/scripts.js
@@ -65,7 +65,7 @@ browserInterop = new (function () {
                 if (!value.getJsObjectRef) {
                     for (let index = 0; index < arguments.length; index++) {
                         const element = arguments[index];
-                        args.push(me.getSerializableObject(element, [], value.serializationSpec));
+                        args.push(me.getSerializableObject(element, [], value.serializationSpec,value.includeDefaults));
                     }
                 } else {
                     for (let index = 0; index < arguments.length; index++) {
@@ -191,7 +191,7 @@ browserInterop = new (function () {
     this.callInstanceMethodGetRef = function (instance, methodPath, ...args) {
         return this.storeObjectRef(this.callInstanceMethod(instance, methodPath, ...args));
     };
-    this.getSerializableObject = function (data, alreadySerialized, serializationSpec) {
+    this.getSerializableObject = function (data, alreadySerialized, serializationSpec, includeDefaults) {
         if (serializationSpec === false) {
             return undefined;
         }
@@ -220,7 +220,7 @@ browserInterop = new (function () {
             var currentMemberSpec;
             if (serializationSpec != "*") {
                 currentMemberSpec = Array.isArray(data) ? serializationSpec : serializationSpec[i];
-                if (currentMemberSpec == null || currentMemberSpec === undefined) {
+                if ((!includeDefaults && !currentMemberSpec) || (currentMemberSpec === undefined)) {
                     continue;
                 }
             } else {
@@ -236,7 +236,7 @@ browserInterop = new (function () {
                     for (var j = 0; j < currentMember.length; j++) {
                         const arrayItem = currentMember[j];
                         if (typeof arrayItem === 'object') {
-                            res[i].push(me.getSerializableObject(arrayItem, alreadySerialized, currentMemberSpec));
+                            res[i].push(me.getSerializableObject(arrayItem, alreadySerialized, currentMemberSpec, includeDefaults));
                         } else {
                             res[i].push(arrayItem);
                         }
@@ -246,7 +246,7 @@ browserInterop = new (function () {
                     if (currentMember.length === 0) {
                         res[i] = [];
                     } else {
-                        res[i] = me.getSerializableObject(currentMember, alreadySerialized, currentMemberSpec);
+                        res[i] = me.getSerializableObject(currentMember, alreadySerialized, currentMemberSpec, includeDefaults);
                     }
                 }
 


### PR DESCRIPTION
I've added the possibility to debounce callbacks. That reduces the load on browser and network level for callbacks that are invoked very often.

I also found a bug in the serialization filter behavior. I used something like new { myValue = default(int) }. myValue was not included into the serialization because !currentMemberSpec evaluates to false. On the other hand that approach of filtering allowed me to directly use that anonymous type as a deserialization target  type. Specifying something like new {myValue = 1} seems not to be intuitive. 
To avoid breaking changes I made the default value handling configurable.