### PR TITLE
Adds support to finalization of runtime object refs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,4 @@ MigrationBackup/
 test/BrowserInterop.E2ETests/cypress/videos/
 test/BrowserInterop.E2ETests/cypress/screenshots/
 .DS_Store
+.idea


### PR DESCRIPTION
This PR adds support to finalization, which was missing from JsRuntimeObjectRef. This should prevent the build up of a memory leak if objects are not disposed properly, allowing it to both .NET objects and JS objects to be garbage collected.

I also tried to use the in-process API if it is available. This could be even better if I could use the unmarshalled API, but that would require updating Microsoft.JS.Interop package to 5.0.0, which this project has not done yet.

Let me know your thoughts.